### PR TITLE
observe the size attribute; save qr codes for rendering again later.

### DIFF
--- a/qrcode.js
+++ b/qrcode.js
@@ -29,41 +29,71 @@ angular.module('monospaced.qrcode', [])
       restrict: 'E',
       template: '<canvas></canvas>',
       link: function(scope, element, attrs){
+        // dynamic stuff
+        var size, tile;
+        var text;
+        var qr, modules;
 
+        // fixed for the life of the scope
         var domElement = element[0],
             canvas = element.find('canvas')[0],
             version = Math.max(1, Math.min(parseInt(attrs.version, 10), 10)) || 4,
             correction = attrs.errorCorrectionLevel in levels ? attrs.errorCorrectionLevel : 'M',
-            trim = /^\s+|\s+$/g,
-            qr = qrcode(version, correction);
-
-        qr.make();
-
-        var modules = qr.getModuleCount(),
-            size = parseInt(attrs.size, 10) || modules * 2,
-            tile = size / modules,
-            render = function(qr, text){
-              qr.addData(text);
-              qr.make();
-              if (canvas2D) {
-                draw(context, qr, modules, tile);
-              } else {
-                domElement.innerHTML = qr.createImgTag(tile, 0);
-              }
-            };
+            trim = /^\s+|\s+$/g;
 
         if (canvas2D) {
           var context = canvas.getContext('2d');
-          canvas.width = canvas.height = size;
         }
 
-        attrs.$observe('data', function(value){
-          if (!value) {
-            return;
+        var render = function() {
+          if (canvas2D) {
+            draw(context, qr, modules, tile);
+          } else {
+            domElement.innerHTML = qr.createImgTag(tile, 0);
           }
-          var text = value.replace(trim, ''),
-              qr = qrcode(version, correction);
-          render(qr, text);
+        };
+
+        var updateText = function(value) {
+          text = value;
+          qr = qrcode(version, correction);
+          if (typeof text !== 'undefined') {
+            qr.addData(text);
+          }
+          qr.make();
+          if (typeof modules === 'undefined') {
+              modules = qr.getModuleCount();
+          }
+        };
+
+        var updateSize = function(value) {
+          var minSize = modules * 2;
+
+          if (typeof value === 'string') {
+            value = parseInt(value, 10);
+          }
+          value = value || minSize;
+
+          size = value;
+          tile = size / modules;
+          if (canvas2D) {
+            canvas.width = canvas.height = size;
+          }
+        }
+
+        updateText();
+        updateSize(attrs.size);
+
+        attrs.$observe('size', function(value) {
+            updateSize(value);
+            render();
+        })
+
+        attrs.$observe('data', function(value) {
+          if (value) {
+              value = value.replace(trim, '')
+          }
+          updateText(value);
+          render();
         });
       }
     };


### PR DESCRIPTION
First, thanks for writing this directive. It's very cool.

My application needs to resize QR codes on the fly. So I started observing changes in the size attribute and rerendering. I rewrote the render function so that it doesn't require a new `qr` be created on every render.

I didn't want to change the index.html, since that demo is on your gh-pages site. So I put together a demo of resizing on another branch ([demos/observe-size](https://github.com/bmatsuo/angular-qrcode/tree/demos/observe-size)). It's pretty rough but it actually looks pretty cool when you are way zoomed out.
