### PR TITLE
Add margin

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,13 +108,13 @@
     }
   </style>
 </head>
-<body data-ng-init="foo='here comes qr!';bar='https://github.com/monospaced/angular-qrcode';v=4;e='M';s=274;">
+<body data-ng-init="foo='here comes qr!';bar='https://github.com/monospaced/angular-qrcode';v=4;e='M';s=274;m=0;">
 
   <h1>Angular QR Code</h1>
 
   <pre>&lt;qrcode&gt;&lt;/qrcode&gt;</pre>
 
-  <qrcode version="{{v}}" error-correction-level="{{e}}" size="{{s}}" data="{{foo}}"></qrcode>
+  <qrcode version="{{v}}" error-correction-level="{{e}}" size="{{s}}" data="{{foo}}" margin="{{m}}"></qrcode>
 
   <form>
     <p>
@@ -133,15 +133,19 @@
       <label for="level" title="Error Correction Level">Level</label>
       <select id="level" data-ng-model="e" data-ng-options="option.version as option.name for option in [{name:'Low', version:'L'},{name:'Medium', version:'M'},{name:'Quartile', version:'Q'},{name:'High', version:'H'}]"></select>
     </p>
+    <p>
+      <label for="margin">Margin</label>
+      <input id="margin" type="number" data-ng-model="m" min="0" max="50">
+    </p>
   </form>
 
   <h2>Downloadable</h2>
 
-  <qrcode version="{{v}}" error-correction-level="{{e}}" size="{{s}}" data="{{foo}}" download></qrcode>
+  <qrcode version="{{v}}" error-correction-level="{{e}}" size="{{s}}" data="{{foo}}" margin="{{m}}" download></qrcode>
 
   <h2>Linked</h2>
 
-  <qrcode version="{{v}}" error-correction-level="{{e}}" size="{{s}}" data="{{bar}}" href="{{bar}}"></qrcode>
+  <qrcode version="{{v}}" error-correction-level="{{e}}" size="{{s}}" data="{{bar}}" margin="{{m}}" href="{{bar}}"></qrcode>
 
   <form>
     <p>

--- a/qrcode.js
+++ b/qrcode.js
@@ -14,15 +14,15 @@ angular.module('monospaced.qrcode', [])
           'Q': 'Quartile',
           'H': 'High'
         },
-        draw = function(context, qr, modules, tile) {
+        draw = function(context, qr, modules, tile, margin) {
           for (var row = 0; row < modules; row++) {
             for (var col = 0; col < modules; col++) {
               var w = (Math.ceil((col + 1) * tile) - Math.floor(col * tile)),
-                  h = (Math.ceil((row + 1) * tile) - Math.floor(row * tile));
-
+                  h = (Math.ceil((row + 1) * tile) - Math.floor(row * tile)),
+                  x = Math.round(col * tile) + Math.round(margin / 2);
+                  y = Math.round(row * tile) + Math.round(margin / 2)
               context.fillStyle = qr.isDark(row, col) ? '#000' : '#fff';
-              context.fillRect(Math.round(col * tile),
-                               Math.round(row * tile), w, h);
+              context.fillRect(x, y, w, h);
             }
           }
         };
@@ -44,6 +44,7 @@ angular.module('monospaced.qrcode', [])
             errorCorrectionLevel,
             data,
             size,
+            margin,
             modules,
             tile,
             qr,
@@ -75,8 +76,13 @@ angular.module('monospaced.qrcode', [])
             },
             setSize = function(value) {
               size = parseInt(value, 10) || modules * 2;
-              tile = size / modules;
+              tile = (size - margin)/ modules;
               canvas.width = canvas.height = size;
+              context.fillStyle = '#fff';
+              context.fillRect(0, 0, size, size);
+            },
+            setMargin = function(value) {
+              margin = value || 0
             },
             render = function() {
               if (!qr) {
@@ -104,14 +110,14 @@ angular.module('monospaced.qrcode', [])
               }
 
               if (canvas2D) {
-                draw(context, qr, modules, tile);
+                draw(context, qr, modules, tile, margin);
 
                 if (download) {
                   domElement.href = canvas.toDataURL('image/png');
                   return;
                 }
               } else {
-                domElement.innerHTML = qr.createImgTag(tile, 0);
+                domElement.innerHTML = qr.createImgTag(tile, margin);
                 $img = element.find('img');
                 $img.addClass('qrcode');
 
@@ -134,6 +140,7 @@ angular.module('monospaced.qrcode', [])
 
         setVersion(attrs.version);
         setErrorCorrectionLevel(attrs.errorCorrectionLevel);
+        setMargin(attrs.margin);
         setSize(attrs.size);
 
         attrs.$observe('version', function(value) {
@@ -174,6 +181,16 @@ angular.module('monospaced.qrcode', [])
           }
 
           setSize(value);
+          render();
+        });
+
+        attrs.$observe('margin', function(value) {
+          if (!value) {
+            return;
+          }
+
+          setMargin(value);
+          setSize(size);
           render();
         });
 


### PR DESCRIPTION
Hi, this adds a margin to the QR. When background color is dark, position detection pattern is unrecognizable.
