### PR TITLE
Automatically select the version based on data size and apply the href parameter to the <a> element

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ as element
 with QR options
 
     <qrcode version="2" error-correction-level="M" size="200" data="string"></qrcode>
+    
+The amount of data that a qrcode can contain is impacted by the `version` and the `error-correction-level`. 
+`version` designates the density of the encoding. If it isn't specified, it defaults to 4. If the `version` specified
+is too small to contain the data that was given, the next highest `version` will be tried automatically.
+The maximum version supported is `10`.
 
 as a downloadable image
 
@@ -24,9 +29,10 @@ as a downloadable image
 
 as a link to URL
 
-    <qrcode data="http://example.com" href="http://example.com"></qrcode>
+    <qrcode data="http://example.com" href="http://example.com" target="_new"></qrcode>
 
 `download` and `href` can’t be used on the same element (if `download` is present, `href` will be ignored)
+`target` is optional. If it is supplied, it will be applied to the <a> element that wraps the qrcode canvas.
 
 with expressions, observe changes
 

--- a/angular-qrcode.js
+++ b/angular-qrcode.js
@@ -37,6 +37,7 @@ angular.module('monospaced.qrcode', [])
             context = canvas2D ? canvas.getContext('2d') : null,
             download = 'download' in attrs,
             href = attrs.href,
+            target = attrs.target;
             link = download || href ? document.createElement('a') : '',
             trim = /^\s+|\s+$/g,
             error,
@@ -65,8 +66,12 @@ angular.module('monospaced.qrcode', [])
 
               try {
                 qr.make();
-              } catch(e) {
-                error = e.message;
+              } catch (e) {
+                if (version >= 10) {
+                  throw "Data is too long";
+                }
+                setVersion(version + 1);
+                setData(value);
                 return;
               }
 
@@ -120,14 +125,14 @@ angular.module('monospaced.qrcode', [])
                   return;
                 }
               }
-
-              if (href) {
-                domElement.href = href;
-              }
             };
 
         if (link) {
           link.className = 'qrcode-link';
+          link.href = href;
+          if (target) {
+            link.target = target;
+          }
           $canvas.wrap(link);
           domElement = link;
         }

--- a/angular-qrcode.js
+++ b/angular-qrcode.js
@@ -37,7 +37,7 @@ angular.module('monospaced.qrcode', [])
             context = canvas2D ? canvas.getContext('2d') : null,
             download = 'download' in attrs,
             href = attrs.href,
-            target = attrs.target;
+            target = attrs.target,
             link = download || href ? document.createElement('a') : '',
             trim = /^\s+|\s+$/g,
             error,


### PR DESCRIPTION
- Retry with a higher density qrcode if the supplied data doesn't fit.
- Throw an exception when the supplied data won't fit in the maximum density.
- Fix the wrapping link so that it has an href.
- Add the option to specify a target for the link.
