### PR TITLE
Add support for configurable download file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ with QR options
 
 as a downloadable image
 
-    <qrcode data="string" download></qrcode>
+    <qrcode data="string" download-file-name="myQrCode" download></qrcode>
 
 as a link to URL
 
@@ -53,6 +53,8 @@ Permitted values
 * size: integer
 
 * download: boolean
+
+* download-file-name: name to download file as, without extension
 
 * href: URL
 

--- a/angular-qrcode.js
+++ b/angular-qrcode.js
@@ -36,7 +36,7 @@ angular.module('monospaced.qrcode', [])
             canvas = $canvas[0],
             context = canvas2D ? canvas.getContext('2d') : null,
             download = 'download' in attrs,
-			downloadFileName = attrs.downloadFileName,
+            downloadFileName = attrs.downloadFileName,
             href = attrs.href,
             link = download || href ? document.createElement('a') : '',
             trim = /^\s+|\s+$/g,
@@ -100,9 +100,9 @@ angular.module('monospaced.qrcode', [])
               }
 
               if (download) {
-				if(!downloadFileName){
-					downloadFileName = 'qrcode';
-				}
+                if(!downloadFileName){
+                    downloadFileName = 'qrcode';
+                }
                 domElement.download = downloadFileName + '.png';
                 domElement.title = 'Download QR code';
               }

--- a/angular-qrcode.js
+++ b/angular-qrcode.js
@@ -36,6 +36,7 @@ angular.module('monospaced.qrcode', [])
             canvas = $canvas[0],
             context = canvas2D ? canvas.getContext('2d') : null,
             download = 'download' in attrs,
+			downloadFileName = attrs.downloadFileName,
             href = attrs.href,
             link = download || href ? document.createElement('a') : '',
             trim = /^\s+|\s+$/g,
@@ -99,7 +100,10 @@ angular.module('monospaced.qrcode', [])
               }
 
               if (download) {
-                domElement.download = 'qrcode.png';
+				if(!downloadFileName){
+					downloadFileName = 'qrcode';
+				}
+                domElement.download = downloadFileName + '.png';
                 domElement.title = 'Download QR code';
               }
 

--- a/index.html
+++ b/index.html
@@ -137,7 +137,7 @@
 
   <h2>Downloadable</h2>
 
-  <qrcode version="{{v}}" error-correction-level="{{e}}" size="{{s}}" data="{{foo}}" download></qrcode>
+  <qrcode version="{{v}}" error-correction-level="{{e}}" size="{{s}}" data="{{foo}}" download-file-name="myQrCode" download></qrcode>
 
   <h2>Linked</h2>
 


### PR DESCRIPTION
With this change the library now looks for an additional attribute (download-file-name) from the QR element and uses that as the file name.  If the attribute is not found, we default to the original name 'qrcode.png'.
