### PR TITLE
different display and download size

### DIFF
--- a/index.html
+++ b/index.html
@@ -146,6 +146,8 @@
     </p>
   </form>
 
+  <h2>Different display and download size</h2>
+  <qrcode size="274" data="{{bar}}" download-size="500" download></qrcode>
   <div class="footer">
 
     <small>


### PR DESCRIPTION
First of all thanks for sharing your directive!

I have added additional functionality. It is now possible to set different download and display size via an additional attribute download-size. The additional downlad information is encoded inside a invisible canvas element.

Best regards michael