### PR TITLE
Add support for specifying the tile size rather

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ Permitted values
 
 * `error-correction-level`: `L`, `M`, `Q`, `H` (default: `M`)
 
-* `size`: `integer` (default: `size` is calculated automatically)
+* `tile`: `integer` (default: 2)
+
+* `size`: `integer` (default: `size` is calculated automatically based on version and tile size)
 
 * `download`: `boolean` (default: `false`)
 
@@ -137,6 +139,8 @@ Permitted values
 * `color`: `hex` as `string` (default: `#000`)
 
 * `background`: `hex` as `string` (default: `#fff`)
+
+It does not make sense to specify both `tile` and `size`: either include `tile` and the size will be computed automatically based on version and tile size (`tile`), or include `size` and the tile size will be computed automatically based on version and size.
 
 The amount of data (measured in bits) must be within capacity according to the `version` and `error correction level`, see http://www.qrcode.com/en/about/version.html.
 

--- a/angular-qrcode.js
+++ b/angular-qrcode.js
@@ -97,8 +97,13 @@ angular.module('monospaced.qrcode', [])
               modules = qr.getModuleCount();
             },
             setSize = function(value) {
-              size = parseInt(value, 10) || modules * 2;
+              size = parseInt(value, 10) || modules * tile;
               tile = size / modules;
+              canvas.width = canvas.height = size;
+            },
+            setTile = function(value) {
+	      tile = parseInt(value, 10) || 2;
+              size = modules * tile;
               canvas.width = canvas.height = size;
             },
             render = function() {
@@ -159,6 +164,7 @@ angular.module('monospaced.qrcode', [])
         setBackground(attrs.background);
         setVersion(attrs.version);
         setErrorCorrectionLevel(attrs.errorCorrectionLevel);
+        setTile(attrs.tile);
         setSize(attrs.size);
 
         attrs.$observe('version', function(value) {
@@ -199,6 +205,15 @@ angular.module('monospaced.qrcode', [])
           }
 
           setSize(value);
+          render();
+        });
+
+        attrs.$observe('tile', function(value) {
+          if (!value) {
+            return;
+          }
+
+          setTile(value);
           render();
         });
 

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
 
   <pre>&lt;qrcode&gt;&lt;/qrcode&gt;</pre>
 
-  <qrcode error-correction-level="{{e}}" size="{{s}}" data="{{foo}}" color="#FF69B4" background="#000"></qrcode>
+  <qrcode error-correction-level="{{e}}" size="{{s}}" tile="{{t}}" data="{{foo}}" color="#FF69B4" background="#000"></qrcode>
 
   <form>
     <p>
@@ -126,6 +126,10 @@
       <input id="size" type="number" data-ng-model="s">
     </p>
     <p>
+      <label for="tile">Tile size</label>
+      <input id="tile" type="number" data-ng-model="t">
+    </p>
+    <p>
       <label for="level" title="Error Correction Level">Level</label>
       <select id="level" data-ng-model="e" data-ng-options="option.version as option.name for option in [{name:'Low', version:'L'},{name:'Medium', version:'M'},{name:'Quartile', version:'Q'},{name:'High', version:'H'}]"></select>
     </p>
@@ -133,7 +137,7 @@
 
   <h2>Downloadable</h2>
 
-  <qrcode error-correction-level="{{e}}" size="{{s}}" data="{{foo}}" download></qrcode>
+  <qrcode error-correction-level="{{e}}" size="{{s}}" tile="{{t}}" data="{{foo}}" download></qrcode>
 
   <h2>Linked</h2>
 
@@ -155,7 +159,7 @@
   </div>
 
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.6.1/angular.min.js"></script>
-  <script src="//kazuhikoarase.github.io/qrcode-generator/js/demo/assets/qrcode.js"></script>
+  <script src="node_modules/qrcode-generator/qrcode.js"></script>
   <script src="angular-qrcode.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Can be used instead of the total size. This helps having an integer tile size to make the QR code crisper.