### PR TITLE
添加支持二维码中间展示logo图片

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,13 @@ Permitted values
 
 * `background`: `hex` as `string` (default: `#fff`)
 
+* `logo-img`: `url` as `string`
+
+* `logo-size`: `integer`
+
 The amount of data (measured in bits) must be within capacity according to the `version` and `error correction level`, see http://www.qrcode.com/en/about/version.html.
+
+if logo-img or logo-size is null,logo will not be show;
 
 Demo
 ----------------

--- a/angular-qrcode.js
+++ b/angular-qrcode.js
@@ -145,7 +145,7 @@ angular.module('monospaced.qrcode', [])
               if (canvas2D) {
                 draw(context, qr, modules, tile, color);
   
-                if(logoImg && logoSize){
+                if(logoImg && logoSize && !isNaN(logoSize)){
                   drawImage(context,logoImg,size,logoSize)
                 }
                 

--- a/angular-qrcode.js
+++ b/angular-qrcode.js
@@ -31,6 +31,14 @@ angular.module('monospaced.qrcode', [])
                                Math.round(row * tile), w, h);
             }
           }
+        },
+        drawImage=function(context,imgUrl,size,logoImgSize){
+          var img = new Image();
+          img.onload = function(){
+            context.drawImage(img,(size-logoImgSize)/2,(size-logoImgSize)/2,logoImgSize,logoImgSize)
+          }
+      
+          img.src = imgUrl;
         };
 
     return {
@@ -54,6 +62,8 @@ angular.module('monospaced.qrcode', [])
             tile,
             qr,
             $img,
+            logoImg = attrs.logoImg,
+            logoSize = attrs.logoSize,
             color = {
               foreground: '#000',
               background: '#fff'
@@ -96,6 +106,12 @@ angular.module('monospaced.qrcode', [])
               error = false;
               modules = qr.getModuleCount();
             },
+            setLogoImg = function(value) {
+              logoImg = value;
+            },
+            setLogoSize = function(value) {
+              logoSize = parseInt(value, 10) || modules * 2;
+            },
             setSize = function(value) {
               size = parseInt(value, 10) || modules * 2;
               tile = size / modules;
@@ -128,7 +144,11 @@ angular.module('monospaced.qrcode', [])
 
               if (canvas2D) {
                 draw(context, qr, modules, tile, color);
-
+  
+                if(logoImg && logoSize){
+                  drawImage(context,logoImg,size,logoSize)
+                }
+                
                 if (download) {
                   domElement.href = canvas.toDataURL('image/png');
                   return;
@@ -160,6 +180,8 @@ angular.module('monospaced.qrcode', [])
         setVersion(attrs.version);
         setErrorCorrectionLevel(attrs.errorCorrectionLevel);
         setSize(attrs.size);
+        setLogoImg(attrs.logoImg);
+        setLogoSize(attrs.logoSize);
 
         attrs.$observe('version', function(value) {
           if (!value) {
@@ -226,6 +248,22 @@ angular.module('monospaced.qrcode', [])
           }
 
           href = value;
+          render();
+        });
+        
+        attrs.$observe('logoImg', function(value) {
+          if (!value) {
+            return;
+          }
+          setLogoImg(value)
+          render();
+        });
+        
+        attrs.$observe('logoSize', function(value) {
+          if (!value) {
+            return;
+          }
+          setLogoSize(value)
           render();
         });
       }

--- a/angular-qrcode.js
+++ b/angular-qrcode.js
@@ -34,6 +34,7 @@ angular.module('monospaced.qrcode', [])
         },
         drawImage=function(context,imgUrl,size,logoImgSize){
           var img = new Image();
+          img.setAttribute("crossOrigin",'Anonymous')
           img.onload = function(){
             context.drawImage(img,(size-logoImgSize)/2,(size-logoImgSize)/2,logoImgSize,logoImgSize)
           }


### PR DESCRIPTION
添加支持二维码中间展示logo图片,通过logo-img和logo-size属性设置logo样式